### PR TITLE
Set oauth 2.0 as the default standard

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -76,6 +76,7 @@ description: |-
 - `client_id` (String)
 - `client_secret` (String, Sensitive)
 - `id` (String) The ID of this resource.
+- `oauth_standard` (String)
 
 <a id="nestedatt--custom_providers"></a>
 ### Nested Schema for `custom_providers`

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -124,6 +124,7 @@ type App struct {
 	RegisterWithLoginInformation    bool    `json:"register_with_login_information"`
 	AppOwner                        string  `json:"app_owner,omitempty"`
 	BotProvider                     string  `json:"bot_provider,omitempty"`
+	OauthStandard                   string  `json:"oauthStandard,omitempty"`
 
 	AppKey *AppKey `json:"appKey,omitempty"`
 

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -107,6 +107,7 @@ type App struct {
 	RegisterWithLoginInformation    types.Bool   `tfsdk:"register_with_login_information"`
 	AppKey                          types.Object `tfsdk:"app_key"`
 	TemplateGroupId                 types.String `tfsdk:"template_group_id"`
+	OauthStandard                   types.String `tfsdk:"oauth_standard"`
 
 	AllowedGroups                    types.List       `tfsdk:"allowed_groups"`
 	OperationsAllowedGroups          types.List       `tfsdk:"operations_allowed_groups"`

--- a/internal/provider/resource_app.go
+++ b/internal/provider/resource_app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -93,6 +94,10 @@ func (r *appResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 
 			// App Settings
+			"oauth_standard": schema.StringAttribute{
+				Computed: true,
+				Default:  stringdefault.StaticString("OAuth2.0"),
+			},
 			"client_id": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -528,11 +533,6 @@ func (r appResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		resp.Diagnostics.AddError("Error Updating app", err.Error())
 		return
 	}
-	////@FIXME: Check this
-	//if app.PasswordPolicy != plannedApp.PasswordPolicy {
-	//	resp.Diagnostics.AddWarning("Password policy was updated in cidaas", "Setting password policy to the value after update: "+*app.PasswordPolicy)
-	//	state.PasswordPolicy = types.StringPointerValue(app.PasswordPolicy)
-	//}
 
 	diags = applyAppToState(ctx, &state, app)
 	resp.Diagnostics.Append(diags...)
@@ -630,6 +630,7 @@ func applyAppToState(ctx context.Context, state *App, app *client.App) diag.Diag
 	state.IsLoginSuccessPageEnabled = types.BoolValue(app.IsLoginSuccessPageEnabled)
 	state.JweEnabled = types.BoolValue(app.JweEnabled)
 	state.AlwaysAskMfa = types.BoolValue(app.AlwaysAskMfa)
+	state.OauthStandard = types.StringValue(app.OauthStandard)
 
 	state.AllowedGroups, diags = types.ListValueFrom(ctx, types.ObjectType{
 		AttrTypes: map[string]attr.Type{
@@ -742,6 +743,7 @@ func planToApp(ctx context.Context, plan *App, state *App) (*client.App, diag.Di
 		AlwaysAskMfa:                    plan.AlwaysAskMfa.ValueBool(),
 		RegisterWithLoginInformation:    plan.RegisterWithLoginInformation.ValueBool(),
 		AcceptRolesInTheRegistration:    plan.AcceptRolesInTheRegistration.ValueBool(),
+		OauthStandard:                   plan.OauthStandard.ValueString(),
 
 		AllowLoginWith:               plan.AllowLoginWith,
 		RedirectUris:                 plan.RedirectUris,


### PR DESCRIPTION
Cidaas has introduced Oauth 2.1 as the default standard, among of the changes introduced with it is that makes more strict the usage/validation of URLs, so in order to avoid that we are defining Oauth2.0 as default standard.